### PR TITLE
fix: env by prefix panic

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,25 +25,6 @@ func GetEnv(key, fallback string) string {
 		return value
 	}
 	return fallback
-}
-
-// GetEnvsByPrefix finds all ENV vars that start with prefix
-// GetEnvsByPrefix func takes no as input and returns prefix string, strip bool map[string]string
-func GetEnvsByPrefix(prefix string, strip bool) map[string]string {
-	envs := make(map[string]string)
-	for _, e := range os.Environ() {
-		pair := strings.Split(e, "=")
-		if strings.HasPrefix(pair[0], prefix) {
-			if len(pair[1]) > 0 {
-				k := pair[0]
-				if strip {
-					k = strings.TrimPrefix(pair[0], prefix)
-				}
-				envs[k] = pair[1]
-			}
-		}
-	}
-	return envs
 }
 
 // NewULID returns a ULID.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -38,7 +38,7 @@ func GetEnvsByPrefix(prefix string, strip bool) map[string]string {
 			if len(pair[1]) > 0 {
 				k := pair[0]
 				if strip {
-					k = strings.Split(pair[0], prefix+"_")[1]
+					k = strings.TrimPrefix(pair[0], prefix)
 				}
 				envs[k] = pair[1]
 			}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -19,15 +19,19 @@ func TestGetEnv(t *testing.T) {
 	assert.Assert(t, bar == "42")
 }
 
-// TestGetEnvsByPrefix
 func TestGetEnvsByPrefix(t *testing.T) {
-	// 46 and 2
 	os.Setenv("GET_ENV_PREFIX_FOO", "46")
 	os.Setenv("GET_ENV_PREFIX_BAR", "2")
-	prefix := "GET_ENV_PREFIX"
+	os.Setenv("GET_ENV_PREFIX.BAZ", "21") // doesn't match prefix
+	os.Setenv("GET_ENV_PREFIX_", "99")
+	os.Setenv("GET_ENV_PREFIX_GET_ENV_PREFIX_FOOBAR", "25")
+	prefix := "GET_ENV_PREFIX_"
 	tokens := GetEnvsByPrefix(prefix, true)
 	assert.Assert(t, tokens["FOO"] == "46")
 	assert.Assert(t, tokens["BAR"] == "2")
+	assert.Assert(t, tokens["BAZ"] == "")
+	assert.Assert(t, tokens[""] == "99")
+	assert.Assert(t, tokens["GET_ENV_PREFIX_FOOBAR"] == "25")
 }
 
 func TestNewULID(t *testing.T) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -19,21 +19,6 @@ func TestGetEnv(t *testing.T) {
 	assert.Assert(t, bar == "42")
 }
 
-func TestGetEnvsByPrefix(t *testing.T) {
-	os.Setenv("GET_ENV_PREFIX_FOO", "46")
-	os.Setenv("GET_ENV_PREFIX_BAR", "2")
-	os.Setenv("GET_ENV_PREFIX.BAZ", "21") // doesn't match prefix
-	os.Setenv("GET_ENV_PREFIX_", "99")
-	os.Setenv("GET_ENV_PREFIX_GET_ENV_PREFIX_FOOBAR", "25")
-	prefix := "GET_ENV_PREFIX_"
-	tokens := GetEnvsByPrefix(prefix, true)
-	assert.Assert(t, tokens["FOO"] == "46")
-	assert.Assert(t, tokens["BAR"] == "2")
-	assert.Assert(t, tokens["BAZ"] == "")
-	assert.Assert(t, tokens[""] == "99")
-	assert.Assert(t, tokens["GET_ENV_PREFIX_FOOBAR"] == "25")
-}
-
 func TestNewULID(t *testing.T) {
 	u, err := NewULID()
 	assert.NilError(t, err, "error is not nil")


### PR DESCRIPTION
GetEnvsByPrefix split on a prefix not guaranteed to exist, risking panics when indexing the resulting slice.

A bit of logic is changed or defined in tests I want input on:
- Caller now must provide exact prefix they want, e.g., `MY_PREFIX_`, instead of `MY_PREFIX`
- If a key matches the prefix exactly (prefix `BLAH` and key `BLAH`), it is inserted into the returned map with an empty string key

Closes #25 