### PR TITLE
refactor: graph fields in snake case

### DIFF
--- a/docs/how-to/start-server/README.md
+++ b/docs/how-to/start-server/README.md
@@ -82,7 +82,7 @@ mutation {
       name: "grant"
       version: "1.0.0"
       release: "some-action"
-      platformID: "platformID"
+      platform_id: "platformID"
       package: "package"
       description: "a fake event receiver"
       payload: "{\"name\": \"value\"}"

--- a/docs/tutorials/workshops/hello_world/README.md
+++ b/docs/tutorials/workshops/hello_world/README.md
@@ -117,7 +117,7 @@ mutation {
       name: "foo"
       version: "1.0.0"
       release: "20231103"
-      platformID: "platformID"
+      platform_id: "platformID"
       package: "package"
       description: "The Foo of Brixton"
       payload: "{\"name\": \"value\"}"

--- a/pkg/api/graphql/schema/types/event.graphql
+++ b/pkg/api/graphql/schema/types/event.graphql
@@ -1,5 +1,5 @@
 type Event {
-  ID: ID!
+  id: ID!
   name: String!
   version: String!
   release: String!
@@ -16,7 +16,7 @@ input EventInput {
   name: String!
   version: String!
   release: String!
-  platformID: String!
+  platform_id: String!
   package: String!
   description: String!
   payload: JSON!

--- a/pkg/api/graphql/schema/types/event_reciever.graphql
+++ b/pkg/api/graphql/schema/types/event_reciever.graphql
@@ -1,5 +1,5 @@
 type EventReceiver {
-  ID: ID!
+  id: ID!
   name: String!
   type: String!
   version: String!

--- a/pkg/api/graphql/schema/types/event_reciever_group.graphql
+++ b/pkg/api/graphql/schema/types/event_reciever_group.graphql
@@ -1,5 +1,5 @@
 type EventReceiverGroup {
-  ID: ID!
+  id: ID!
   name: String!
   type: String!
   version: String!


### PR DESCRIPTION
Small pr to give graph fields consistent naming. The instance of `platformID` was more egregious but I went ahead and lowercase'd the `id` fields as well.