### PR TITLE
fix: stop returning pointers to lists of objects from graphql #50

### DIFF
--- a/pkg/api/graphql/resolvers/mutations.go
+++ b/pkg/api/graphql/resolvers/mutations.go
@@ -46,7 +46,7 @@ type EventReceiverGroupInput struct {
 	EventReceiverIDs []graphql.ID
 }
 
-func (r *MutationResolver) CreateEvent(args struct{ Event EventInput }) (*graphql.ID, error) {
+func (r *MutationResolver) CreateEvent(args struct{ Event EventInput }) (graphql.ID, error) {
 	// TODO: centralize this and make it look better
 	eventInput := storage.Event{
 		Name:            args.Event.Name,
@@ -63,16 +63,16 @@ func (r *MutationResolver) CreateEvent(args struct{ Event EventInput }) (*graphq
 	event, err := storage.CreateEvent(r.Connection.Client, eventInput)
 	if err != nil {
 		logger.Error(err, "error creating event", "input", eventInput)
-		return nil, err
+		return "", err
 	}
 
 	r.kafkaCfg.MsgChannel <- message.NewEvent(event)
 
 	logger.V(1).Info("created", "event", event)
-	return &event.ID, nil
+	return event.ID, nil
 }
 
-func (r *MutationResolver) CreateEventReceiver(args struct{ EventReceiver EventReceiverInput }) (*graphql.ID, error) {
+func (r *MutationResolver) CreateEventReceiver(args struct{ EventReceiver EventReceiverInput }) (graphql.ID, error) {
 	// TODO: centralize this and make it look better
 	eventReceiverInput := storage.EventReceiver{
 		Name:        args.EventReceiver.Name,
@@ -85,16 +85,16 @@ func (r *MutationResolver) CreateEventReceiver(args struct{ EventReceiver EventR
 	eventReceiver, err := storage.CreateEventReceiver(r.Connection.Client, eventReceiverInput)
 	if err != nil {
 		logger.Error(err, "error creating event receiver", "input", eventReceiverInput)
-		return nil, err
+		return "", err
 	}
 
 	r.kafkaCfg.MsgChannel <- message.NewEventReceiver(eventReceiver)
 
 	logger.V(1).Info("created", "eventReceiver", eventReceiver)
-	return &eventReceiver.ID, nil
+	return eventReceiver.ID, nil
 }
 
-func (r *MutationResolver) CreateEventReceiverGroup(args struct{ EventReceiverGroup EventReceiverGroupInput }) (*graphql.ID, error) {
+func (r *MutationResolver) CreateEventReceiverGroup(args struct{ EventReceiverGroup EventReceiverGroupInput }) (graphql.ID, error) {
 	// TODO: centralize this and make it look better
 	eventReceiverGroupInput := storage.EventReceiverGroup{
 		Name:             args.EventReceiverGroup.Name,
@@ -108,31 +108,31 @@ func (r *MutationResolver) CreateEventReceiverGroup(args struct{ EventReceiverGr
 	eventReceiverGroup, err := storage.CreateEventReceiverGroup(r.Connection.Client, eventReceiverGroupInput)
 	if err != nil {
 		logger.Error(err, "error creating event receiver group", "input", eventReceiverGroupInput)
-		return nil, err
+		return "", err
 	}
 
 	r.kafkaCfg.MsgChannel <- message.NewEventReceiverGroup(eventReceiverGroup)
 
 	logger.V(1).Info("created", "eventReceiverGroup", eventReceiverGroup)
-	return &eventReceiverGroup.ID, nil
+	return eventReceiverGroup.ID, nil
 }
 
-func (r *MutationResolver) SetEventReceiverGroupEnabled(args struct{ ID graphql.ID }) (*graphql.ID, error) {
+func (r *MutationResolver) SetEventReceiverGroupEnabled(args struct{ ID graphql.ID }) (graphql.ID, error) {
 	err := storage.SetEventReceiverGroupEnabled(r.Connection.Client, args.ID, true)
 	if err != nil {
 		logger.Error(err, "error setting event receiver group enabled", "id", args.ID)
-		return nil, err
+		return "", err
 	}
 	logger.V(1).Info("updated", "eventReceiverGroupEnabled", args.ID)
-	return &args.ID, nil
+	return args.ID, nil
 }
 
-func (r *MutationResolver) SetEventReceiverGroupDisabled(args struct{ ID graphql.ID }) (*graphql.ID, error) {
+func (r *MutationResolver) SetEventReceiverGroupDisabled(args struct{ ID graphql.ID }) (graphql.ID, error) {
 	err := storage.SetEventReceiverGroupEnabled(r.Connection.Client, args.ID, false)
 	if err != nil {
 		logger.Error(err, "error setting event receiver group disabled", "id", args.ID)
-		return nil, err
+		return "", err
 	}
 	logger.V(1).Info("updated", "eventReceiverGroupDisabled", args.ID)
-	return &args.ID, nil
+	return args.ID, nil
 }

--- a/pkg/api/graphql/resolvers/query.go
+++ b/pkg/api/graphql/resolvers/query.go
@@ -9,14 +9,14 @@ type QueryResolver struct {
 	Connection *storage.Database
 }
 
-func (r *QueryResolver) Events(args struct{ ID graphql.ID }) (*[]*storage.Event, error) {
+func (r *QueryResolver) Events(args struct{ ID graphql.ID }) ([]storage.Event, error) {
 	return storage.FindEvent(r.Connection.Client, args.ID)
 }
 
-func (r *QueryResolver) EventReceivers(args struct{ ID graphql.ID }) (*[]*storage.EventReceiver, error) {
+func (r *QueryResolver) EventReceivers(args struct{ ID graphql.ID }) ([]storage.EventReceiver, error) {
 	return storage.FindEventReceiver(r.Connection.Client, args.ID)
 }
 
-func (r *QueryResolver) EventReceiverGroups(args struct{ ID graphql.ID }) (*[]*storage.EventReceiverGroup, error) {
+func (r *QueryResolver) EventReceiverGroups(args struct{ ID graphql.ID }) ([]storage.EventReceiverGroup, error) {
 	return storage.FindEventReceiverGroup(r.Connection.Client, args.ID)
 }

--- a/pkg/api/graphql/schema/schema.graphql
+++ b/pkg/api/graphql/schema/schema.graphql
@@ -4,16 +4,16 @@ schema {
 }
 
 type Query {
-  events(id: ID!): [Event]
-  event_receivers(id: ID!): [EventReceiver]
-  event_receiver_groups(id: ID!): [EventReceiverGroup]
+  events(id: ID!): [Event!]!
+  event_receivers(id: ID!): [EventReceiver!]!
+  event_receiver_groups(id: ID!): [EventReceiverGroup!]!
 }
 
 type Mutation {
-  create_event(event: EventInput!): ID
-  create_event_receiver(event_receiver: EventReceiverInput!): ID
-  create_event_receiver_group(event_receiver_group: EventReceiverGroupInput!): ID
+  create_event(event: EventInput!): ID!
+  create_event_receiver(event_receiver: EventReceiverInput!): ID!
+  create_event_receiver_group(event_receiver_group: EventReceiverGroupInput!): ID!
 
-  set_event_receiver_group_enabled(id: ID!): ID
-  set_event_receiver_group_disabled(id: ID!): ID
+  set_event_receiver_group_enabled(id: ID!): ID!
+  set_event_receiver_group_disabled(id: ID!): ID!
 }

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -67,7 +67,7 @@ func CreateEvent(tx *gorm.DB, event Event) (*Event, error) {
 	if len(receivers) > 1 {
 		return nil, fmt.Errorf("more than one receiver was found with ID %s", event.EventReceiverID)
 	}
-	receiver := (receivers)[0]
+	receiver := receivers[0]
 
 	if err := validateReceiverSchema(receiver.Schema.String(), event.Payload); err != nil {
 		return nil, err

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -64,10 +64,10 @@ func CreateEvent(tx *gorm.DB, event Event) (*Event, error) {
 		return nil, fmt.Errorf("could not validate event schema. %w", err)
 	}
 
-	if len(*receivers) > 1 {
+	if len(receivers) > 1 {
 		return nil, fmt.Errorf("more than one receiver was found with ID %s", event.EventReceiverID)
 	}
-	receiver := (*receivers)[0]
+	receiver := (receivers)[0]
 
 	if err := validateReceiverSchema(receiver.Schema.String(), event.Payload); err != nil {
 		return nil, err
@@ -78,12 +78,12 @@ func CreateEvent(tx *gorm.DB, event Event) (*Event, error) {
 	if results.Error != nil {
 		return nil, pgError(results.Error)
 	}
-	event.EventReceiver = *receiver
+	event.EventReceiver = receiver
 	return &event, nil
 }
 
-func FindEvent(tx *gorm.DB, id graphql.ID) (*[]*Event, error) {
-	var events []*Event
+func FindEvent(tx *gorm.DB, id graphql.ID) ([]Event, error) {
+	var events []Event
 	result := tx.Model(&Event{}).Preload("EventReceiver").First(&events, &Event{ID: id})
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -91,7 +91,7 @@ func FindEvent(tx *gorm.DB, id graphql.ID) (*[]*Event, error) {
 		}
 		return nil, pgError(result.Error)
 	}
-	return &events, nil
+	return events, nil
 }
 
 func CreateEventReceiver(tx *gorm.DB, eventReceiver EventReceiver) (*EventReceiver, error) {
@@ -113,8 +113,8 @@ func CreateEventReceiver(tx *gorm.DB, eventReceiver EventReceiver) (*EventReceiv
 }
 
 // FindEventReceiver tries to find an event receiver by ID.
-func FindEventReceiver(tx *gorm.DB, id graphql.ID) (*[]*EventReceiver, error) {
-	var eventReceivers []*EventReceiver
+func FindEventReceiver(tx *gorm.DB, id graphql.ID) ([]EventReceiver, error) {
+	var eventReceivers []EventReceiver
 	result := tx.Model(&EventReceiver{}).First(&eventReceivers, &EventReceiver{ID: id})
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
@@ -122,7 +122,7 @@ func FindEventReceiver(tx *gorm.DB, id graphql.ID) (*[]*EventReceiver, error) {
 		}
 		return nil, pgError(result.Error)
 	}
-	return &eventReceivers, nil
+	return eventReceivers, nil
 }
 
 func CreateEventReceiverGroup(tx *gorm.DB, eventReceiverGroup EventReceiverGroup) (*EventReceiverGroup, error) {
@@ -156,7 +156,7 @@ func CreateEventReceiverGroup(tx *gorm.DB, eventReceiverGroup EventReceiverGroup
 	}
 	return &eventReceiverGroup, nil
 }
-func FindEventReceiverGroup(tx *gorm.DB, id graphql.ID) (*[]*EventReceiverGroup, error) {
+func FindEventReceiverGroup(tx *gorm.DB, id graphql.ID) ([]EventReceiverGroup, error) {
 	var eventReceiverGroup EventReceiverGroup
 	result := tx.Model(&EventReceiverGroup{}).First(&eventReceiverGroup, &EventReceiverGroup{ID: id})
 	if result.Error != nil {
@@ -176,7 +176,7 @@ func FindEventReceiverGroup(tx *gorm.DB, id graphql.ID) (*[]*EventReceiverGroup,
 		return nil, pgError(result.Error)
 	}
 
-	return &[]*EventReceiverGroup{&eventReceiverGroup}, nil
+	return []EventReceiverGroup{eventReceiverGroup}, nil
 }
 
 func SetEventReceiverGroupEnabled(tx *gorm.DB, id graphql.ID, enabled bool) error {


### PR DESCRIPTION
When I did this last time we had  pointers to pointers to pointers. Ick. Fixes that.