### PR TITLE
refactor: decompose api.Initialize() & make more dependency-injectable

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-chi/render"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sassoftware/event-provenance-registry/pkg/config"
-	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/status"
 	"github.com/sassoftware/event-provenance-registry/pkg/storage"
 	"github.com/sassoftware/event-provenance-registry/pkg/utils"
@@ -29,20 +28,6 @@ func Initialize(ctx context.Context, db *storage.Database, cfg *config.Config) (
 	if cfg == nil {
 		return nil, fmt.Errorf("no config provided")
 	}
-
-	// set up kafka
-	kafkaCfg, err := message.NewConfig(cfg.Kafka.Version)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	cfg.Kafka.Producer, err = message.NewProducer(cfg.Kafka.Peers, kafkaCfg)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	cfg.Kafka.Producer.ConsumeSuccesses()
-	cfg.Kafka.Producer.ConsumeErrors()
 
 	s, err := New(ctx, db, cfg.Kafka)
 	if err != nil {

--- a/pkg/api/graphql/graphql.go
+++ b/pkg/api/graphql/graphql.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/graph-gophers/graphql-go/relay"
 	"github.com/sassoftware/event-provenance-registry/pkg/api/graphql/schema"
-	"github.com/sassoftware/event-provenance-registry/pkg/config"
+	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/storage"
 )
 
 type Server struct {
 	DBConnector *storage.Database
-	kafkaCfg    *config.KafkaConfig
+	msgProducer message.TopicProducer
 }
 
-func New(conn *storage.Database, cfg *config.KafkaConfig) *Server {
+func New(conn *storage.Database, msgProducer message.TopicProducer) *Server {
 	return &Server{
 		DBConnector: conn,
-		kafkaCfg:    cfg,
+		msgProducer: msgProducer,
 	}
 }
 
@@ -32,6 +32,6 @@ func (s *Server) ServerGraphQLDoc() http.HandlerFunc {
 }
 
 func (s *Server) GraphQLHandler() http.HandlerFunc {
-	handler := &relay.Handler{Schema: schema.New(s.DBConnector, s.kafkaCfg)}
+	handler := &relay.Handler{Schema: schema.New(s.DBConnector, s.msgProducer)}
 	return handler.ServeHTTP
 }

--- a/pkg/api/graphql/graphql.go
+++ b/pkg/api/graphql/graphql.go
@@ -31,7 +31,7 @@ func (s *Server) ServerGraphQLDoc() http.HandlerFunc {
 	}
 }
 
-func (s *Server) GraphQLHandler(connection *storage.Database, cfg *config.KafkaConfig) http.HandlerFunc {
-	handler := &relay.Handler{Schema: schema.New(connection, cfg)}
+func (s *Server) GraphQLHandler() http.HandlerFunc {
+	handler := &relay.Handler{Schema: schema.New(s.DBConnector, s.kafkaCfg)}
 	return handler.ServeHTTP
 }

--- a/pkg/api/graphql/resolvers/mutations.go
+++ b/pkg/api/graphql/resolvers/mutations.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sassoftware/event-provenance-registry/pkg/api/graphql/schema/types"
-	"github.com/sassoftware/event-provenance-registry/pkg/config"
 	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/storage"
 )
@@ -14,8 +13,8 @@ import (
 // is used to establish a connection to a database and perform various database operations such as
 // querying and modifying data.
 type MutationResolver struct {
-	Connection *storage.Database
-	kafkaCfg   *config.KafkaConfig
+	Connection  *storage.Database
+	msgProducer message.TopicProducer
 }
 
 type EventInput struct {
@@ -66,7 +65,7 @@ func (r *MutationResolver) CreateEvent(args struct{ Event EventInput }) (*graphq
 		return nil, err
 	}
 
-	r.kafkaCfg.MsgChannel <- message.NewEvent(event)
+	r.msgProducer.Async(message.NewEvent(event))
 
 	logger.V(1).Info("created", "event", event)
 	return &event.ID, nil
@@ -88,7 +87,7 @@ func (r *MutationResolver) CreateEventReceiver(args struct{ EventReceiver EventR
 		return nil, err
 	}
 
-	r.kafkaCfg.MsgChannel <- message.NewEventReceiver(eventReceiver)
+	r.msgProducer.Async(message.NewEventReceiver(eventReceiver))
 
 	logger.V(1).Info("created", "eventReceiver", eventReceiver)
 	return &eventReceiver.ID, nil
@@ -111,7 +110,7 @@ func (r *MutationResolver) CreateEventReceiverGroup(args struct{ EventReceiverGr
 		return nil, err
 	}
 
-	r.kafkaCfg.MsgChannel <- message.NewEventReceiverGroup(eventReceiverGroup)
+	r.msgProducer.Async(message.NewEventReceiverGroup(eventReceiverGroup))
 
 	logger.V(1).Info("created", "eventReceiverGroup", eventReceiverGroup)
 	return &eventReceiverGroup.ID, nil

--- a/pkg/api/graphql/resolvers/resolver.go
+++ b/pkg/api/graphql/resolvers/resolver.go
@@ -1,7 +1,7 @@
 package resolvers
 
 import (
-	"github.com/sassoftware/event-provenance-registry/pkg/config"
+	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/storage"
 	"github.com/sassoftware/event-provenance-registry/pkg/utils"
 )
@@ -9,14 +9,14 @@ import (
 var logger = utils.MustGetLogger("server", "pkg.api.graphql.resolvers")
 
 type Resolver struct {
-	Connection *storage.Database
-	kafkaCfg   *config.KafkaConfig
+	Connection  *storage.Database
+	msgProducer message.TopicProducer
 }
 
-func New(connection *storage.Database, cfg *config.KafkaConfig) *Resolver {
+func New(connection *storage.Database, msgProducer message.TopicProducer) *Resolver {
 	return &Resolver{
-		Connection: connection,
-		kafkaCfg:   cfg,
+		Connection:  connection,
+		msgProducer: msgProducer,
 	}
 }
 
@@ -28,7 +28,7 @@ func (r *Resolver) Query() *QueryResolver {
 
 func (r *Resolver) Mutation() *MutationResolver {
 	return &MutationResolver{
-		Connection: r.Connection,
-		kafkaCfg:   r.kafkaCfg,
+		Connection:  r.Connection,
+		msgProducer: r.msgProducer,
 	}
 }

--- a/pkg/api/graphql/schema/schema.go
+++ b/pkg/api/graphql/schema/schema.go
@@ -11,17 +11,17 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sassoftware/event-provenance-registry/pkg/api/graphql/resolvers"
-	"github.com/sassoftware/event-provenance-registry/pkg/config"
+	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/storage"
 )
 
-func New(connection *storage.Database, cfg *config.KafkaConfig) *graphql.Schema {
+func New(connection *storage.Database, msgProducer message.TopicProducer) *graphql.Schema {
 	s, err := String()
 	if err != nil {
 		log.Fatalf("reading embedded schema contents: %s", err)
 	}
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers()}
-	return graphql.MustParseSchema(s, resolvers.New(connection, cfg), opts...)
+	return graphql.MustParseSchema(s, resolvers.New(connection, msgProducer), opts...)
 }
 
 //go:embed *.graphql types/*.graphql

--- a/pkg/api/rest/event.go
+++ b/pkg/api/rest/event.go
@@ -43,7 +43,7 @@ func (s *Server) createEvent(r *http.Request) (graphql.ID, error) {
 		return "", err
 	}
 
-	s.kafkaCfg.MsgChannel <- message.NewEvent(event)
+	s.msgProducer.Async(message.NewEvent(event))
 	logger.V(1).Info("created", "event", event)
 	return event.ID, nil
 }

--- a/pkg/api/rest/group.go
+++ b/pkg/api/rest/group.go
@@ -71,7 +71,7 @@ func (s *Server) createGroup(r *http.Request) (graphql.ID, error) {
 		return "", err
 	}
 
-	s.kafkaCfg.MsgChannel <- message.NewEventReceiverGroup(eventReceiverGroup)
+	s.msgProducer.Async(message.NewEventReceiverGroup(eventReceiverGroup))
 	logger.V(1).Info("created", "eventReceiverGroup", eventReceiverGroup)
 
 	return eventReceiverGroup.ID, nil

--- a/pkg/api/rest/receiver.go
+++ b/pkg/api/rest/receiver.go
@@ -56,7 +56,7 @@ func (s *Server) createReceiver(r *http.Request) (graphql.ID, error) {
 		return "", err
 	}
 
-	s.kafkaCfg.MsgChannel <- message.NewEventReceiver(eventReceiver)
+	s.msgProducer.Async(message.NewEventReceiver(eventReceiver))
 	logger.V(1).Info("created", "eventReceiver", eventReceiver)
 	return eventReceiver.ID, nil
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -4,12 +4,11 @@
 package api
 
 import (
-	"context"
 	"errors"
 
 	"github.com/sassoftware/event-provenance-registry/pkg/api/graphql"
 	"github.com/sassoftware/event-provenance-registry/pkg/api/rest"
-	"github.com/sassoftware/event-provenance-registry/pkg/config"
+	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/storage"
 )
 
@@ -18,12 +17,12 @@ type Server struct {
 	Rest    *rest.Server
 }
 
-func New(ctx context.Context, conn *storage.Database, config *config.KafkaConfig) (*Server, error) {
+func New(conn *storage.Database, msgProducer message.TopicProducer) (*Server, error) {
 	if conn == nil {
 		return nil, errors.New("database connector cannot be nil")
 	}
 	return &Server{
-		GraphQL: graphql.New(conn, config),
-		Rest:    rest.New(ctx, conn, config),
+		GraphQL: graphql.New(conn, msgProducer),
+		Rest:    rest.New(conn, msgProducer),
 	}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sassoftware/event-provenance-registry/pkg/message"
 	"github.com/sassoftware/event-provenance-registry/pkg/utils"
 )
 
@@ -63,12 +62,10 @@ type AuthConfig struct {
 
 // KafkaConfig holds config information about Kafka
 type KafkaConfig struct {
-	TLS        bool                 `json:"tls"`
-	Version    string               `json:"version"`
-	Topic      string               `json:"topic"`
-	Peers      []string             `json:"peers"`
-	Producer   message.Producer     `json:"-"`
-	MsgChannel chan message.Message `json:"-"`
+	TLS     bool     `json:"tls"`
+	Version string   `json:"version"`
+	Topic   string   `json:"topic"`
+	Peers   []string `json:"peers"`
 }
 
 // LogConfigInfo Dumps most of the config info to the log.
@@ -132,14 +129,13 @@ func WithServer(host, port, resourceDir string, debug, verbose bool) Options {
 }
 
 // WithKafka returns an option that sets the kafka config
-func WithKafka(tls bool, version string, peers []string, topic string, channel chan message.Message) Options {
+func WithKafka(tls bool, version string, peers []string, topic string) Options {
 	return func(cfg *Config) error {
 		cfg.Kafka = &KafkaConfig{
-			TLS:        tls,
-			Version:    version,
-			Peers:      peers,
-			Topic:      topic,
-			MsgChannel: channel,
+			TLS:     tls,
+			Version: version,
+			Peers:   peers,
+			Topic:   topic,
 		}
 		return nil
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,7 +11,7 @@ func TestNewConfig(t *testing.T) {
 	cfg, err := New(
 		WithServer("localhost", "8080", "/resources", true, true),
 		WithStorage("clash.london.com", "joe", "brixton", "foo", "posgres", 5432, 10, 10, 10),
-		WithKafka(true, "2.6", []string{"kafka.svc.cluster.local:9092"}, "server.events", nil),
+		WithKafka(true, "2.6", []string{"kafka.svc.cluster.local:9092"}, "server.events"),
 		WithAuth("ABCDEFGHIJK", []string{"foo", "bar"}),
 	)
 

--- a/pkg/message/produce.go
+++ b/pkg/message/produce.go
@@ -212,3 +212,30 @@ func (p *producer) Send(topic string, value interface{}) error {
 
 	return nil
 }
+
+type TopicProducer interface {
+	Async(data any)
+	Send(data any) error
+}
+
+type topicProducer struct {
+	producer Producer
+	topic    string
+}
+
+// NewTopicProducer wraps the given producer into an interface for sending
+// messages without knowledge of message-bus details, such as topic
+func NewTopicProducer(p Producer, topic string) TopicProducer {
+	return &topicProducer{
+		producer: p,
+		topic:    topic,
+	}
+}
+
+func (t *topicProducer) Async(data any) {
+	t.producer.Async(t.topic, data)
+}
+
+func (t *topicProducer) Send(data any) error {
+	return t.producer.Send(t.topic, data)
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -45,7 +45,7 @@ func TestTheStatus(t *testing.T) {
 	cfg, err := config.New(
 		config.WithServer("localhost", port, "/resources", true, true),
 		config.WithStorage("postgres", "user", "pass", "ssl", "postgres", 5432, 10, 10, 10),
-		config.WithKafka(true, "2.6", strings.Split(brokers, ","), topic, nil),
+		config.WithKafka(true, "2.6", strings.Split(brokers, ","), topic),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The monstrous `api.Initialize()` kept bothering me, believe this addresses all my concerns. Main points:
- Let root cmd construct deps, pass them into `api` pkg (DI)
- Create new interface in `pkg/message` to simplify producer usage
- Stop passing around entire app's config

Diffs may look a little unruly, highly recommend looking through this commit-by-commit since the 3rd one is where most work occurred.

Keeping as draft until I can add some tests.