### PR TITLE
test: fix failures in graphql client pkg

### DIFF
--- a/pkg/client/graphql_test.go
+++ b/pkg/client/graphql_test.go
@@ -34,9 +34,12 @@ func TestNewGraphQLRequestWithList(t *testing.T) {
 		"id":      "01HKMQM136XW7JYP2293N4EBR4",
 		"version": "1.0.0",
 	}
-	expected := `query FindEventReceiverGroups($id: ID!,$version: String){groups(id: $id,version: $version) {id,name,version,type}}`
+	expected := []string{
+		`query FindEventReceiverGroups($id: ID!,$version: String){groups(id: $id,version: $version) {id,name,version,type}}`,
+		`query FindEventReceiverGroups($version: String,$id: ID!){groups(version: $version,id: $id) {id,name,version,type}}`,
+	}
 	req := NewGraphQLRequest(queryName, lookFor, params, fields)
-	assert.Equal(t, req.Query, expected, "The generated Query did not match expected")
+	assert.Check(t, customStringCompare(req.Query, expected))
 }
 
 func TestNewGraphQLRequestWithInt(t *testing.T) {
@@ -48,7 +51,7 @@ func TestNewGraphQLRequestWithInt(t *testing.T) {
 		"start": 1,
 	}
 	expected := []string{`query FindEvents($name: String,$start: Int){events(name: $name,start: $start) {name,id}}`,
-		`query FindEvent($start: Int,$name: String){events(start: $start,name: $name) {name,id}}`}
+		`query FindEvents($start: Int,$name: String){events(start: $start,name: $name) {name,id}}`}
 	req := NewGraphQLRequest(queryName, lookFor, params, fields)
 	assert.Check(t, customStringCompare(req.Query, expected))
 }
@@ -63,9 +66,14 @@ func TestComplexNewGraphQLRequest(t *testing.T) {
 		"success": true,
 	}
 
-	expected := []string{`query foo($success: Bool,$id: ID!,$name: String){bar(success: $success,id: $id,name: $name) {name,id,success}}`,
+	expected := []string{
+		`query foo($success: Bool,$id: ID!,$name: String){bar(success: $success,id: $id,name: $name) {name,id,success}}`,
+		`query foo($success: Bool,$name: String,$id: ID!){bar(success: $success,name: $name,id: $id) {name,id,success}}`,
 		`query foo($id: ID!,$name: String,$success: Bool){bar(id: $id,name: $name,success: $success) {name,id,success}}`,
-		`query foo($name: String,$success: Bool,$id: ID!){bar(name: $name,success: $success,id: $id) {name,id,success}}`}
+		`query foo($id: ID!,$success: Bool,$name: String){bar(id: $id,success: $success,name: $name) {name,id,success}}`,
+		`query foo($name: String,$success: Bool,$id: ID!){bar(name: $name,success: $success,id: $id) {name,id,success}}`,
+		`query foo($name: String,$id: ID!,$success: Bool){bar(name: $name,id: $id,success: $success) {name,id,success}}`,
+	}
 	req := NewGraphQLRequest(queryName, lookFor, params, fields)
 	assert.Check(t, customStringCompare(req.Query, expected))
 }


### PR DESCRIPTION
Graphql client tests occasionally fail due to non-deterministic iteration order of maps. "Fix" is to make sure all order permutations are listed.

To reproduce, run the tests a bunch: `go test ./... -count=100`

```go
--- FAIL: TestNewGraphQLRequestWithList (0.00s)
    graphql_test.go:39: assertion failed: query FindEventReceiverGroups($version: String,$id: ID!){groups(version: $version,id: $id) {id,name,version,type}} (req.Query string) != query FindEventReceiverGroups($id: ID!,$version: String){
groups(id: $id,version: $version) {id,name,version,type}} (expected string): The generated Query did not match expected
--- FAIL: TestNewGraphQLRequestWithInt (0.00s)
    graphql_test.go:56: assertion failed: "query FindEvents($start: Int,$name: String){events(start: $start,name: $name) {name,id}}" did not match available options [query FindEvents($name: String,$start: Int){events(name: $name,start: 
$start) {name,id}} query FindEvent($start: Int,$name: String){events(start: $start,name: $name) {name,id}}]
```

Alternatively, the `params` parameter for `NewGraphQLRequest()` could be changed to a slice so we have deterministic ordering for test assertions. For instance, a slice of `type GraphQLParam { Key: string, Value: any }`. Didn't make this change since I wasn't sure how the func is meant to be used, any thoughts?