### PR TITLE
fix: find by id should return err if not found

### DIFF
--- a/pkg/api/rest/event.go
+++ b/pkg/api/rest/event.go
@@ -26,9 +26,6 @@ func (s *Server) GetEventByID() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "eventID")
 		event, err := storage.FindEventByID(s.DBConnector.Client, graphql.ID(id))
-		if err != nil {
-			err = eprErrors.MissingObjectError{Msg: err.Error()}
-		}
 		handleResponse(w, r, event, err)
 	}
 }

--- a/pkg/api/rest/group.go
+++ b/pkg/api/rest/group.go
@@ -33,9 +33,6 @@ func (s *Server) GetGroupByID() http.HandlerFunc {
 		id := chi.URLParam(r, "groupID")
 		slog.Info("GetGroupByID", "groupID", id)
 		rec, err := storage.FindEventReceiverGroupByID(s.DBConnector.Client, graphql.ID(id))
-		if err != nil {
-			err = eprErrors.MissingObjectError{Msg: err.Error()}
-		}
 		handleResponse(w, r, rec, err)
 	}
 }

--- a/pkg/api/rest/receiver.go
+++ b/pkg/api/rest/receiver.go
@@ -28,9 +28,6 @@ func (s *Server) GetReceiverByID() http.HandlerFunc {
 		id := chi.URLParam(r, "receiverID")
 		slog.Info("getting receiver", "id", id)
 		eventReceiver, err := storage.FindEventReceiverByID(s.DBConnector.Client, graphql.ID(id))
-		if err != nil {
-			err = eprErrors.MissingObjectError{Msg: err.Error()}
-		}
 		handleResponse(w, r, eventReceiver, err)
 	}
 }

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -91,16 +91,23 @@ func CreateEvent(tx *gorm.DB, event Event) (*Event, error) {
 }
 
 func FindEventByID(tx *gorm.DB, id graphql.ID) ([]Event, error) {
-	return FindEvent(tx, map[string]any{"id": id})
+	events, err := FindEvent(tx, map[string]any{"id": id})
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, eprErrors.MissingObjectError{Msg: fmt.Sprintf("event with id %s not found", id)}
+	}
+	if len(events) > 1 {
+		return nil, fmt.Errorf("found multiple events with id %s", id)
+	}
+	return events, nil
 }
 
 func FindEvent(tx *gorm.DB, e map[string]any) ([]Event, error) {
 	var events []Event
 	result := tx.Model(&Event{}).Preload("EventReceiver").Where(e).Find(&events)
 	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, eprErrors.MissingObjectError{Msg: fmt.Sprintf("event %+v not found", e)}
-		}
 		return nil, pgError(result.Error)
 	}
 	return events, nil
@@ -124,19 +131,26 @@ func CreateEventReceiver(tx *gorm.DB, eventReceiver EventReceiver) (*EventReceiv
 	return &eventReceiver, nil
 }
 
-// FindEventReceiver tries to find an event receiver by ID.
+// FindEventReceiverByID tries to find an event receiver by ID.
 func FindEventReceiverByID(tx *gorm.DB, id graphql.ID) ([]EventReceiver, error) {
-	return FindEventReceiver(tx, map[string]any{"id": id})
+	receivers, err := FindEventReceiver(tx, map[string]any{"id": id})
+	if err != nil {
+		return nil, err
+	}
+	if len(receivers) == 0 {
+		return nil, eprErrors.MissingObjectError{Msg: fmt.Sprintf("eventReceiver with id %s not found", id)}
+	}
+	if len(receivers) > 1 {
+		return nil, fmt.Errorf("found multiple eventReceivers with id %s", id)
+	}
+	return receivers, nil
 }
 
-// FindEventReceiver tries to find an event receiver by ID.
+// FindEventReceiver tries to find an event receiver by matching fields
 func FindEventReceiver(tx *gorm.DB, er map[string]any) ([]EventReceiver, error) {
 	var eventReceivers []EventReceiver
 	result := tx.Model(&EventReceiver{}).Where(er).Find(&eventReceivers)
 	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, eprErrors.MissingObjectError{Msg: fmt.Sprintf("eventReceiver %+v not found", er)}
-		}
 		return nil, pgError(result.Error)
 	}
 	return eventReceivers, nil
@@ -175,16 +189,23 @@ func CreateEventReceiverGroup(tx *gorm.DB, eventReceiverGroup EventReceiverGroup
 }
 
 func FindEventReceiverGroupByID(tx *gorm.DB, id graphql.ID) ([]EventReceiverGroup, error) {
-	return FindEventReceiverGroup(tx, map[string]any{"id": id})
+	groups, err := FindEventReceiverGroup(tx, map[string]any{"id": id})
+	if err != nil {
+		return nil, err
+	}
+	if len(groups) == 0 {
+		return nil, eprErrors.MissingObjectError{Msg: fmt.Sprintf("eventReceiverGroup with id %s not found", id)}
+	}
+	if len(groups) > 1 {
+		return nil, fmt.Errorf("found multiple eventReceiverGroups with id %s", id)
+	}
+	return groups, nil
 }
 
 func FindEventReceiverGroup(tx *gorm.DB, erg map[string]any) ([]EventReceiverGroup, error) {
 	var eventReceiverGroup EventReceiverGroup
 	result := tx.Model(&EventReceiverGroup{}).Where(erg).Find(&eventReceiverGroup)
 	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, eprErrors.MissingObjectError{Msg: fmt.Sprintf("eventReceiverGroup %+v not found", erg)}
-		}
 		return nil, pgError(result.Error)
 	}
 


### PR DESCRIPTION
Latest merge had issue where, through rest, querying for resources by id would return an empty data array and no errors.

This occurs because db searching was switched from `First()` to `Where(<filter>).Find()`. The latter does not return `gorm.ErrRecordNotFound`, so our code needs a check for empty results.

This PR fixes that issue, along with some adjacent error fixes. Primarily, errors bubbled up to the rest pkg from storage should not be wrapped in `eprErrors.MissingObjectError`. Not all errors from the db indicate missing objects (such as connection issues), so the storage layer should interpret errors and surface what it can.